### PR TITLE
fix: allow spaces in catalog names

### DIFF
--- a/src/lib/components/ColorCustomizer.svelte
+++ b/src/lib/components/ColorCustomizer.svelte
@@ -171,6 +171,12 @@
 
 		// Keyboard shortcuts
 		const handleKeyPress = (e: KeyboardEvent) => {
+			// Don't intercept keystrokes when user is typing in an input field
+			const target = e.target as HTMLElement;
+			if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT' || target.isContentEditable)) {
+				return;
+			}
+
 			if (e.key === ' ' && !isOpen) {
 				e.preventDefault();
 				toggleAutoCycle();


### PR DESCRIPTION
The ColorCustomizer's global keydown handler was intercepting the spacebar key even when the user was typing in an input field (e.g., the catalog title editor). Added a check to skip shortcut handling when the event target is an INPUT, TEXTAREA, SELECT, or contenteditable element.

Fixes #19

Generated with [Claude Code](https://claude.ai/code)